### PR TITLE
Remove prettier/@typescript-eslint from extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ module.exports = {
         'eslint:recommended',
         'plugin:react/recommended',
         'plugin:@typescript-eslint/recommended',
-        'prettier/@typescript-eslint',
         'plugin:prettier/recommended',
         'plugin:jest/recommended',
         'plugin:cypress/recommended',


### PR DESCRIPTION
Stop extending prettier/@typescript-eslint since it is merged in the latter versions of eslint-config-prettier 8.0.0 otherwise below errors are returned

Error: Cannot read config file: /Users/michael.ta/code/my-beequip/node_modules/eslint-config-prettier/@typescript-eslint.js
Error: "prettier/@typescript-eslint" has been merged into "prettier" in eslint-config-prettier 8.0.0.
<br>
https://stackoverflow.com/questions/65675771/eslint-couldnt-find-the-config-prettier-typescript-eslint-after-relocating

